### PR TITLE
Add option for selects in template configuration

### DIFF
--- a/app/helpers/admin/pages_helper.rb
+++ b/app/helpers/admin/pages_helper.rb
@@ -28,14 +28,33 @@ module Admin
 
     def page_block_field(form, block_name, block_options)
       labelled_field(
-        form.send(
-          block_options[:size] == :field ? :text_field : :text_area,
-          block_name,
-          page_block_field_options(block_options)
-        ),
+        if block_options[:type] == :select
+          page_block_select(form, block_name, block_options)
+        else
+          page_block_text_field(form, block_name, block_options)
+        end,
         block_options[:title],
         errors: form.object.errors[block_name],
         description: block_options[:description]
+      )
+    end
+
+    def page_block_select(form, block_name, block_options)
+      template_options = if block_options[:options].is_a?(Hash)
+                           block_options[:options][form.object.locale.to_sym]
+                         else
+                           block_options[:options]
+                         end
+      form.send(:select, block_name, ([""] +
+                                      template_options +
+                                      [form.object.send(block_name)]).uniq)
+    end
+
+    def page_block_text_field(form, block_name, block_options)
+      form.send(
+        block_options[:size] == :field ? :text_field : :text_area,
+        block_name,
+        page_block_field_options(block_options)
       )
     end
 

--- a/lib/pages_core/templates/configuration.rb
+++ b/lib/pages_core/templates/configuration.rb
@@ -1,5 +1,85 @@
 module PagesCore
   module Templates
+    # = Template configuration
+    #
+    # Configuration DSL for the page templates. Can be accessed through
+    # +PagesCore::Templates.configure+.
+    #
+    #   PagesCore::Templates.configure do |config|
+    #     # Configuration goes here
+    #   end
+    #
+    # == Configuring templates
+    #
+    # Defaults for all templates can be configured with:
+    #
+    #   config.default do |default|
+    #     default.enabled_blocks %i[name headline body]
+    #     default.files :disabled
+    #   end
+    #
+    # Individual template configurations override the defaults.
+    #
+    #   config.template(:article, :article_alt) do |t|
+    #     t.enabled_blocks %i[name headline excerpt body boxout]
+    #     t.files :enabled
+    #   end
+    #
+    # == Options
+    #
+    # [blocks]
+    #   Yields the block configuration.
+    # [enabled_blocks]
+    #   List of enabled blocks. Default: +%i[headline excerpt body]+
+    # [template]
+    #   Template for all pages, unless overridden with +sub_template+.
+    #   It will attempt to guess based on the parent page if set to
+    #   +:autodetect+, which is the default value. Pass the +:root+
+    #   option to set template at root level.
+    # [image]
+    #   Enable images. Default: +:enabled+
+    # [files]
+    #   Enable file uploads. Default: +:disabled+
+    # [tags]
+    #   Enable tags. Default: +:disabled+
+    # [dates]
+    #   Enable dates. Default: +:disabled+
+    # [sub_template]
+    #   Children of the page will automatically have this template if
+    #   configured. Defaults to +nil+, which fall back to the behaviour
+    #   of +template+.
+    #
+    # == Block configuration
+    #
+    # Blocks can be configured at top level, or per template:
+    #
+    #   config.default do |default|
+    #     default.blocks do |block|
+    #       block.byline("Byline", size: :field)
+    #       block.embed("Video embed", size: :small, description: "Embed code")
+    #     end
+    #     default.enabled_blocks %i[headline byline body embed]
+    #   end
+    #
+    # Valid sizes for text blocks are +:field+ (single line), +:small+
+    # and +:large+.
+    #
+    # === Select blocks
+    #
+    # Blocks can also be selects:
+    #
+    #   block.foobar("Foobar", type: :select, options: %w[Foo Bar Baz])
+    #
+    # Pass a hash for multiple localizations:
+    #
+    #   block.foobar("Foobar", type: :select,
+    #                options: { en: %w[Foo Bar Baz],
+    #                           nb: %w[Fuu Baer Baez] })
+    #
+    # Options can be set at runtime using a Proc:
+    #
+    #   block.foobar("Foobar", type: :select,
+    #                options: -> { FooBar.template_options })
     class Configuration < PagesCore::Templates::ConfigurationHandler
       handle :default do |instance, name, *args|
         if name == :blocks


### PR DESCRIPTION
Example:

```ruby
config.template(:index) do |t|
  t.blocks do |block|
    block.foobar("Foobar", type: :select, options: %w[Foo Bar Baz])
  end
end
```

Localized options are also supported:

```ruby
config.template(:index) do |t|
  t.blocks do |block|
    block.foobar("Foobar",
                 type: :select,
                 options: { en: %w[Foo Bar Baz],
                            nb: %w[Foo Bar Baz] })
  end
end
```

Use a proc to determine values at runtime:

```ruby
config.template(:index) do |t|
  t.blocks do |block|
    block.foobar("Foobar", type: :select, options: -> { %w[Foo Bar Baz] })
  end
end
```