### PR TITLE
gemspec: drop rubyforge_project, it is EOL

### DIFF
--- a/pages_core.gemspec
+++ b/pages_core.gemspec
@@ -12,8 +12,6 @@ Gem::Specification.new do |s|
   s.summary     = "Pages Core"
   s.description = "Pages Core"
 
-  s.rubyforge_project = "."
-
   s.required_ruby_version = ">= 2.1.0"
 
   s.files = Dir[


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.