### PR TITLE
fix(meta_tags): force og:url encoding to UTF-8

### DIFF
--- a/app/helpers/pages_core/head_tags_helper.rb
+++ b/app/helpers/pages_core/head_tags_helper.rb
@@ -68,7 +68,7 @@ module PagesCore
         title: open_graph_title(record),
         image: meta_image(record),
         description: open_graph_description(record)&.strip,
-        url: request.url }
+        url: request.url.dup.force_encoding(Encoding::UTF_8) }
     end
 
     def open_graph_tags(record = nil)

--- a/spec/helpers/pages_core/head_tags_helper_spec.rb
+++ b/spec/helpers/pages_core/head_tags_helper_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PagesCore::HeadTagsHelper do
+  describe "#pages_meta_tags" do
+    before { PagesCore.configure { |c| c.site_name = "Test Site" } }
+
+    it "renders without raising when the request URL has BINARY encoding" do
+      # Some clients (e.g. crawlers) send non-URL-encoded UTF-8 bytes in the
+      # query string. Rack exposes QUERY_STRING as ASCII-8BIT, so request.url
+      # ends up BINARY with non-ASCII bytes. Without forcing UTF-8 here, that
+      # poisons the ERB output buffer's encoding and later tags raise
+      # Encoding::CompatibilityError.
+      helper.request.env["QUERY_STRING"] = "q=Jørgen Moltubak".b
+      output = helper.pages_meta_tags
+      expect(output.encoding).to eq(Encoding::UTF_8)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Crawlers sometimes send non-URL-encoded UTF-8 bytes in the query string. Rack exposes `QUERY_STRING` as ASCII-8BIT, so `request.url` ends up BINARY with non-ASCII bytes.
- Interpolating that into the `og:url` meta tag in `pages_meta_tags` corrupted the ERB output buffer's encoding from UTF-8 to ASCII-8BIT, causing the next tag emitting non-ASCII UTF-8 (e.g. `feed_tags` with `"Prosa: På sisteplass"`) to raise `Encoding::CompatibilityError`.
- Reproduced and confirmed against prosa Sentry issues PROSA-2G and PROSA-2J (24+2 occurrences, both `AuthorsController#index`).

## Test plan
- [x] Added regression spec that fails without the fix and passes with it
- [x] `bundle exec rspec spec/helpers` — 34 examples, 0 failures
- [x] `bundle exec rubocop` on changed files — clean
