### PR TITLE
fix(tree): guard next_sibling/previous_sibling when self not in siblings

### DIFF
--- a/app/models/concerns/pages_core/page_model/tree.rb
+++ b/app/models/concerns/pages_core/page_model/tree.rb
@@ -83,8 +83,10 @@ module PagesCore
         def next_sibling
           return unless persisted? && siblings.any?
 
-          siblings[(siblings.to_a.index(self) + 1)...siblings.length]
-            .try(&:first)
+          index = siblings.to_a.index(self)
+          return unless index
+
+          siblings[(index + 1)...siblings.length].try(&:first)
         end
 
         # Returns the pages parent
@@ -97,11 +99,14 @@ module PagesCore
           localized_subpages.published
         end
 
-        # Finds the page's next sibling. Returns nil if there isn't one.
+        # Finds the page's previous sibling. Returns nil if there isn't one.
         def previous_sibling
           return unless persisted? && siblings.any?
 
-          siblings[0...siblings.to_a.index(self)].try(&:last)
+          index = siblings.to_a.index(self)
+          return unless index
+
+          siblings[0...index].try(&:last)
         end
 
         # Returns the root node of the tree.

--- a/spec/models/concerns/pages_core/page_model/tree_spec.rb
+++ b/spec/models/concerns/pages_core/page_model/tree_spec.rb
@@ -77,6 +77,18 @@ describe PagesCore::PageModel::Tree do
 
       it { is_expected.to be_nil }
     end
+
+    context "when page is not in siblings (e.g. parent reassigned in memory)" do
+      let(:other_root) { create(:page) }
+      let(:page) { create(:page, parent: root) }
+
+      before do
+        create(:page, parent: other_root)
+        page.parent_page_id = other_root.id
+      end
+
+      it { is_expected.to be_nil }
+    end
   end
 
   describe "#parent" do
@@ -120,6 +132,18 @@ describe PagesCore::PageModel::Tree do
       before do
         page
         last
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when page is not in siblings (e.g. parent reassigned in memory)" do
+      let(:other_root) { create(:page) }
+      let(:page) { create(:page, parent: root) }
+
+      before do
+        create(:page, parent: other_root)
+        page.parent_page_id = other_root.id
       end
 
       it { is_expected.to be_nil }


### PR DESCRIPTION
## Summary
- `next_sibling` raised `NoMethodError: undefined method '+' for nil` when `siblings.to_a.index(self)` returned `nil` — reproduced via `PagesController#preview` when `assign_attributes` reassigns `parent_page_id` in memory, putting `self` outside the (newly-resolved) parent's `pages` collection.
- `previous_sibling` had the same latent issue, silently returning the last sibling of the wrong tree instead of `nil`.
- Both methods now bail out early when `index(self)` is `nil`.

Closes Sentry LITTERATURHUSETISKIEN-10 and LITTERATURHUSETISKIEN-11.

## Test plan
- [x] New regression specs cover the "parent reassigned in memory" case for both methods; both fail on `main` (one with the exact `NoMethodError`, the other returning a stranger page) and pass with the fix
- [x] Full `tree_spec.rb` passes (22 examples)
- [x] RuboCop clean
