### PR TITLE
fix: require TLD in email validation

### DIFF
--- a/app/models/concerns/pages_core/emailable.rb
+++ b/app/models/concerns/pages_core/emailable.rb
@@ -9,10 +9,21 @@ module PagesCore
                 presence: true,
                 format: { with: URI::MailTo::EMAIL_REGEXP },
                 uniqueness: { case_sensitive: false }
+      validate :email_domain_has_tld
 
       normalizes :email, with: lambda { |email|
         email.gsub(/[\u200B-\u200D\uFEFF]/, "").strip
       }
+    end
+
+    private
+
+    def email_domain_has_tld
+      return if email.blank?
+      return unless email.to_s.match?(URI::MailTo::EMAIL_REGEXP)
+      return if email.to_s.split("@", 2).last.include?(".")
+
+      errors.add(:email, :invalid)
     end
   end
 end

--- a/spec/models/invite_spec.rb
+++ b/spec/models/invite_spec.rb
@@ -20,6 +20,7 @@ describe Invite do
     it { is_expected.to allow_value("test@example.com").for(:email) }
     it { is_expected.to allow_value("test+foo@example.com").for(:email) }
     it { is_expected.not_to allow_value("foo").for(:email) }
+    it { is_expected.not_to allow_value("test@example").for(:email) }
   end
 
   describe "#token" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -19,6 +19,7 @@ describe User do
   it { is_expected.to allow_value("test@example.com").for(:email) }
   it { is_expected.to allow_value("test+foo@example.com").for(:email) }
   it { is_expected.not_to allow_value("foo").for(:email) }
+  it { is_expected.not_to allow_value("test@example").for(:email) }
 
   it { is_expected.to allow_value("long enough").for(:password) }
   it { is_expected.not_to allow_value("eep").for(:password) }


### PR DESCRIPTION
## Summary
- `URI::MailTo::EMAIL_REGEXP` accepts addresses without a TLD (e.g. `user@host`), which downstream mail providers reject.
- Add a custom validator on `PagesCore::Emailable` that requires the domain to contain a `.` once the address is otherwise well-formed.
- Regression specs in `invite_spec` and `user_spec`.

## Test plan
- [x] `bundle exec rspec spec/models/invite_spec.rb spec/models/user_spec.rb`
- [x] `bundle exec rubocop` on changed files