### PR TITLE
fix(sentry): exclude PagesCore::NotAuthorized from reports

### DIFF
--- a/lib/pages_core/engine.rb
+++ b/lib/pages_core/engine.rb
@@ -44,6 +44,17 @@ module PagesCore
       )
     end
 
+    initializer "pages_core.sentry", after: :load_config_initializers do
+      next unless defined?(Sentry)
+
+      config = Sentry.configuration
+      next unless config
+
+      unless config.excluded_exceptions.include?("PagesCore::NotAuthorized")
+        config.excluded_exceptions << "PagesCore::NotAuthorized"
+      end
+    end
+
     initializer "pages_core.deprecator" do |app|
       app.deprecators[:pages_core] = PagesCore.deprecator
     end

--- a/spec/lib/pages_core/engine_spec.rb
+++ b/spec/lib/pages_core/engine_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe PagesCore::Engine do
+  describe "pages_core.sentry initializer" do
+    subject(:initializer) do
+      described_class.initializers.find { |i| i.name == "pages_core.sentry" }
+    end
+
+    it "is registered" do
+      expect(initializer).not_to be_nil
+    end
+
+    it "runs after :load_config_initializers so Sentry.configuration is available" do
+      expect(initializer.after).to eq(:load_config_initializers)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Authorization rejections in pages_core admin (e.g. a user without rights opening `/admin/.../pages/:id/edit`) raise `PagesCore::NotAuthorized`, which the engine already maps to a 403 via `ActionDispatch::ExceptionWrapper.rescue_responses`. The exception is still raised first, so Sentry captures it as an error — pure noise.
- Adds a `pages_core.sentry` engine initializer that pushes `"PagesCore::NotAuthorized"` onto `Sentry.configuration.excluded_exceptions`, mirroring what sentry-rails already does for routing/parameter/record-not-found errors via its own `IGNORE_DEFAULT`.
- Initializer is ordered `after: :load_config_initializers` because gem initializers run *before* the app's `config/initializers/sentry.rb` by default — without that, `Sentry.configuration` would be nil. Also guarded with `defined?(Sentry)` and a nil-config check so the gem keeps working in apps without sentry-ruby or in environments where `Sentry.init` was skipped (e.g. test).

## Test plan

- [x] `spec/lib/pages_core/engine_spec.rb` asserts the initializer is registered with the expected `after:` metadata
- [x] Verified at real Rails boot inside `spec/internal` that `pages_core.sentry` resolves *after* `load_config_initializers` in the topologically-sorted initializer list
- [x] `bundle exec rubocop lib/pages_core/engine.rb spec/lib/pages_core/engine_spec.rb` — clean
- [ ] CI green

Resolves the FRITTORD-4E noise (and equivalents on other apps).
