### PR TITLE
Fix: WCAG mandatory baseline for frontend generator

### DIFF
--- a/lib/rails/generators/pages_core/frontend/templates/application.html.erb
+++ b/lib/rails/generators/pages_core/frontend/templates/application.html.erb
@@ -16,9 +16,12 @@
     <%= javascript_include_tag "application" %>
   </head>
   <body>
+    <a class="skip-link" href="#main-content">Skip to Main Content</a>
     <% if Rails.env.development? %>
       <div class="grid-overlay"></div>
     <% end %>
-    <%= yield %>
+    <main id="main-content">
+      <%= yield %>
+    </main>
   </body>
 <% end %>

--- a/lib/rails/generators/pages_core/frontend/templates/stylesheets/components/base.css
+++ b/lib/rails/generators/pages_core/frontend/templates/stylesheets/components/base.css
@@ -4,6 +4,22 @@
   box-sizing: border-box;
 }
 
+.skip-link {
+  position: absolute;
+  top: -100%;
+  left: 1rem;
+  z-index: 9999;
+
+  &:focus {
+    top: 1rem;
+  }
+}
+
+:focus-visible {
+  outline: 2px solid var(--link-color);
+  outline-offset: 2px;
+}
+
 .responsive-embed,
 figure.image {
   margin: 2rem 0rem;


### PR DESCRIPTION
## Summary

Adds WCAG 2.1 AA baseline to the `pages_core:frontend` generator templates so new Pages sites ship with:

- Skip link to `#main-content`
- `<main id="main-content">` landmark around `yield`
- Global `:focus-visible` outline using `--link-color`

**WCAG coverage:** 2.4.1 A, 1.3.1 A, 2.4.7 AA

**Scope:** Generator templates only (`rails g pages_core:frontend`). 

## Follow-up

Deferred: whether header/nav should live outside `<main>` for full 2.4.1 bypass (`yield :header` / `yield :footer`). Separate GitHub issue.