### PR TITLE
Chore: Low-risk WCAG and CSS improvements for frontend generator

### DIFF
--- a/lib/rails/generators/pages_core/frontend/templates/stylesheets/global/animation.css
+++ b/lib/rails/generators/pages_core/frontend/templates/stylesheets/global/animation.css
@@ -1,5 +1,12 @@
+/* Wrap all motion/scroll rules in prefers-reduced-motion: no-preference. */
+
 :root {
   --ease-out: cubic-bezier(0.165, 0.84, 0.44, 1);
   --ease-out-back: cubic-bezier(0.35, 1.47, 0.64, 1);
-  scroll-behavior: smooth;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  :root {
+    scroll-behavior: smooth;
+  }
 }

--- a/lib/rails/generators/pages_core/frontend/templates/stylesheets/global/fonts.css
+++ b/lib/rails/generators/pages_core/frontend/templates/stylesheets/global/fonts.css
@@ -1,6 +1,15 @@
 /*
 @font-face { font-family: "Example";
              font-style: normal;
-             font-weight: 300;
-             src: url("/Example-Regular.woff") format("woff"); }
+             font-weight: 100 900;
+             font-display: swap;
+             src: url("/fonts/Example-Variable.woff2") format("woff2"); }
+
+@font-face { font-family: "Example-Fallback";
+             src: local("Arial");
+             size-adjust: 107%;
+             ascent-override: 90%; }
+
+When enabling custom fonts, set --font-sans in typography.css to
+"Example", "Example-Fallback", sans-serif. Calibrate size-adjust per family.
 */


### PR DESCRIPTION
What:
- Wrap scroll-behavior: smooth in prefers-reduced-motion: no-preference
- Update fonts.css example to variable woff2, font-display: swap, and size-adjust fallback

Why: Safer default for vestibular sensitivity (WCAG 2.3.3) and better font-loading guidance for new Pages sites