### PR TITLE
feat(meta_tags): add og:image size, type and alt

### DIFF
--- a/app/helpers/pages_core/head_tags_helper.rb
+++ b/app/helpers/pages_core/head_tags_helper.rb
@@ -2,17 +2,25 @@
 
 module PagesCore
   module HeadTagsHelper
+    META_IMAGE_SIZE = "1200x"
+
     def document_title_tag(separator: " - ")
       parts = [(document_title if respond_to?(:document_title)),
                PagesCore.config.site_name]
       tag.title(parts.compact_blank.uniq.join(separator))
     end
 
-    def meta_image_url(image, size: "1200x")
+    def meta_image_url(image, size: META_IMAGE_SIZE)
       return if image.blank?
       return image unless image.is_a?(Image)
 
       dynamic_image_url(image, size:, only_path: false)
+    end
+
+    def meta_image_size(image, size: META_IMAGE_SIZE)
+      return unless image.is_a?(Image) && image.size?
+
+      DynamicImage::ImageSizing.new(image).fit(size).floor
     end
 
     def pages_meta_tags(page = nil)
@@ -40,10 +48,12 @@ module PagesCore
     end
 
     def meta_image(record = nil)
-      meta_image_url(
-        content_for(:meta_image) ||
-          record.try(:meta_image) || record.try(:image)
-      )
+      meta_image_url(meta_image_source(record))
+    end
+
+    def meta_image_source(record = nil)
+      content_for(:meta_image) ||
+        record.try(:meta_image) || record.try(:image)
     end
 
     def meta_image_tag(href)
@@ -66,9 +76,26 @@ module PagesCore
       { type: "website",
         site_name: PagesCore.config(:site_name),
         title: open_graph_title(record),
-        image: meta_image(record),
+        **open_graph_image_properties(record),
         description: open_graph_description(record)&.strip,
         url: request.url.dup.force_encoding(Encoding::UTF_8) }
+    end
+
+    def open_graph_image_properties(record = nil)
+      image = meta_image_source(record)
+      return { image: meta_image_url(image) } unless image.is_a?(Image)
+
+      { image: meta_image_url(image),
+        "image:type": image.safe_content_type,
+        **open_graph_image_size(image),
+        "image:alt": image.alternative.presence }
+    end
+
+    def open_graph_image_size(image)
+      size = meta_image_size(image)
+      return {} unless size
+
+      { "image:width": size.x, "image:height": size.y }
     end
 
     def open_graph_tags(record = nil)

--- a/spec/helpers/pages_core/head_tags_helper_spec.rb
+++ b/spec/helpers/pages_core/head_tags_helper_spec.rb
@@ -16,5 +16,87 @@ RSpec.describe PagesCore::HeadTagsHelper do
       output = helper.pages_meta_tags
       expect(output.encoding).to eq(Encoding::UTF_8)
     end
+
+    context "with an image" do
+      let(:image) { create(:image) }
+      let(:page) { create(:page, meta_image: image) }
+
+      it "renders the image width" do
+        expect(helper.pages_meta_tags(page))
+          .to include('<meta property="og:image:width" content="320">')
+      end
+
+      it "renders the image height" do
+        expect(helper.pages_meta_tags(page))
+          .to include('<meta property="og:image:height" content="200">')
+      end
+
+      it "renders the image type" do
+        expect(helper.pages_meta_tags(page))
+          .to include('<meta property="og:image:type" content="image/png">')
+      end
+
+      it "does not render the alternative text when it is blank" do
+        expect(helper.pages_meta_tags(page)).not_to include("og:image:alt")
+      end
+
+      it "renders the resized image URL" do
+        expect(helper.pages_meta_tags(page))
+          .to include(%(<meta property="og:image" content="#{
+            helper.meta_image_url(image)}">))
+      end
+    end
+
+    context "with an image with alternative text" do
+      let(:image) { create(:image, alternative: "A blue square") }
+      let(:page) { create(:page, meta_image: image) }
+
+      it "renders the alternative text" do
+        expect(helper.pages_meta_tags(page))
+          .to include('<meta property="og:image:alt" content="A blue square">')
+      end
+    end
+
+    context "without an image" do
+      let(:page) { create(:page) }
+
+      it "does not render image dimensions" do
+        expect(helper.pages_meta_tags(page)).not_to include("og:image")
+      end
+    end
+
+    context "with a meta image URL string" do
+      before { helper.content_for(:meta_image, "http://example.com/foo.png") }
+
+      it "renders the image" do
+        expect(helper.pages_meta_tags).to include(
+          '<meta property="og:image" content="http://example.com/foo.png">'
+        )
+      end
+
+      it "does not render image dimensions" do
+        expect(helper.pages_meta_tags).not_to include("og:image:width")
+      end
+
+      it "does not render the image type" do
+        expect(helper.pages_meta_tags).not_to include("og:image:type")
+      end
+    end
+  end
+
+  describe "#meta_image_size" do
+    it "returns nil for a string" do
+      expect(helper.meta_image_size("http://example.com/foo.png")).to be_nil
+    end
+
+    it "returns the fitted size of an image" do
+      expect(helper.meta_image_size(create(:image)))
+        .to eq(Vector2d.new(320, 200))
+    end
+
+    it "fits the image to the given size" do
+      expect(helper.meta_image_size(create(:image), size: "100x"))
+        .to eq(Vector2d.new(100, 62))
+    end
   end
 end


### PR DESCRIPTION
Meta's crawler often cannot render the link image on the first share unless the page declares the image dimensions, which surfaces as blank images on scheduled Business Suite posts.

`pages_meta_tags` now emits the full set of image properties whenever the meta image is an `Image` record:

- `og:image:width` / `og:image:height` from `DynamicImage::ImageSizing`, the same computation that produces the size segment of the image URL, so the declared dimensions always match what is served
- `og:image:type` from `safe_content_type`, which accounts for non-web-safe sources being converted to JPEG
- `og:image:alt` from the localized `alternative` attribute, omitted when blank

A meta image supplied as a plain URL string through `content_for(:meta_image)` still yields `og:image` alone.

Closes #223
