### PR TITLE
style: reformat for prettier 3.8.3

### DIFF
--- a/app/javascript/components/drag/useDragUploader.ts
+++ b/app/javascript/components/drag/useDragUploader.ts
@@ -3,10 +3,7 @@ import { useEffect, useState } from "react";
 import * as Drag from "../../types/Drag";
 
 type AnyTouchEvent =
-  | MouseEvent
-  | TouchEvent
-  | React.MouseEvent
-  | React.TouchEvent;
+  MouseEvent | TouchEvent | React.MouseEvent | React.TouchEvent;
 
 type StartDrag<T> = (
   evt: AnyTouchEvent,

--- a/app/javascript/index.ts
+++ b/app/javascript/index.ts
@@ -6,7 +6,10 @@ import RichText from "./features/RichText";
 import contentTabs from "./features/contentTabs";
 
 /** @deprecated Import tombolo directly and use Tombolo.start() instead. */
-export function registerComponent(name: string, component: React.ComponentType) {
+export function registerComponent(
+  name: string,
+  component: React.ComponentType
+) {
   Tombolo.start({ [name]: component });
 }
 


### PR DESCRIPTION
`pnpm run prettier` currently fails on `main`. The security bumps in #226 moved prettier to 3.8.3, which changes two formatting decisions:

- `app/javascript/components/drag/useDragUploader.ts` — the `AnyTouchEvent` union now fits on one line, so the leading-pipe multi-line form is no longer prettier's output
- `app/javascript/index.ts` — `registerComponent`'s signature now breaks across lines

This is the output of `pnpm run prettier:fix`, nothing hand-written.

## Verification

`prettier --check`, `eslint` and `tsc --noEmit` all clean. Whitespace only, no behaviour change.