### PR TITLE
Fix page image exports and stream file contents

### DIFF
--- a/app/models/page_exporter.rb
+++ b/app/models/page_exporter.rb
@@ -32,19 +32,16 @@ class PageExporter
   def export_files(page)
     path = page_path(page).join("attachments")
     page.attachments.each do |file|
-      write_file(
-        path.join([file.content_hash, file.filename].join("-")),
-        file.data
-      )
+      copy_file(path.join([file.content_hash, file.filename].join("-")), file)
     end
   end
 
   def export_images(page)
     path = page_path(page).join("images")
     page.page_images.each do |pi|
-      write_file(
+      copy_file(
         path.join([pi.image.content_hash, pi.image.filename].join("-")),
-        pi.image.data
+        pi.image
       )
     end
   end
@@ -90,6 +87,13 @@ class PageExporter
       .select { |attr| page.send(:"#{attr}?") }
       .map { |attr| ["-- #{attr}: --", page.send(attr).strip].join("\n\n") }
       .join("\n\n\n")
+  end
+
+  def copy_file(path, record)
+    FileUtils.mkdir_p(File.dirname(path))
+    record.open_data do |data|
+      File.open(path, "wb") { |out| IO.copy_stream(data, out) }
+    end
   end
 
   def write_file(path, data)

--- a/app/resources/export/page_image_resource.rb
+++ b/app/resources/export/page_image_resource.rb
@@ -10,10 +10,6 @@ module Export
       object.image.id
     end
 
-    attribute :name do
-      object.image.name
-    end
-
     attribute :alternative do
       object.image.alternative
     end

--- a/spec/models/page_exporter_spec.rb
+++ b/spec/models/page_exporter_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe PageExporter do
+  let(:base_dir) { Pathname.new(Dir.mktmpdir) }
+  let(:page) { create(:page) }
+
+  after { FileUtils.remove_entry(base_dir) }
+
+  def export
+    described_class.new(base_dir).export
+  end
+
+  def exported(dir)
+    Dir.glob(base_dir.join("**", dir, "*")).map { |path| Pathname.new(path) }
+  end
+
+  describe "attachments" do
+    let!(:attachment) { create(:page_file, page:).attachment }
+
+    it "exports one file per attachment" do
+      export
+      expect(exported("attachments").length).to eq(1)
+    end
+
+    it "names the file after the content hash and filename" do
+      export
+      expect(exported("attachments").first.basename.to_s)
+        .to eq("#{attachment.content_hash}-#{attachment.filename}")
+    end
+
+    it "writes the data" do
+      export
+      expect(exported("attachments").first.binread).to eq(attachment.data)
+    end
+  end
+
+  describe "images" do
+    let!(:page_image) do
+      PageImage.create!(page:, image: create(:image), locale: page.locale)
+    end
+
+    it "exports one file per image" do
+      export
+      expect(exported("images").length).to eq(1)
+    end
+
+    it "names the file after the content hash and filename" do
+      export
+      expect(exported("images").first.basename.to_s)
+        .to eq("#{page_image.image.content_hash}-#{page_image.image.filename}")
+    end
+
+    it "writes the data" do
+      export
+      expect(exported("images").first.binread).to eq(page_image.image.data)
+    end
+  end
+end


### PR DESCRIPTION
Two fixes to `PageExporter`, which had no test coverage at all.

`Export::PageImageResource` serialized `object.image.name`, which has never existed — the `images` table has no such column, and `Image`'s `localizable` block declares only `alternative` and `caption`. Exporting any page with an image raised `NoMethodError`. Dead since the attribute was introduced in b3733c31.

The exporter also read each attachment and image fully into a Ruby string before writing it, so peak memory tracked the largest file in the site. It now copies through the open descriptor with `open_data` and `IO.copy_stream`.

Adds `spec/models/page_exporter_spec.rb` covering both the attachment and image branches.
